### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You may run into CORs issues when attempting to run locally, these are the worka
 These are not ideal to be running full time. If I find a better solution, will be adding.
 
 - Chrome-based: Add --allow-file-access-from-files
-- Firefox-baed: about:config -> security.fileuri.strict_origin_policy -> false
+- Firefox-based: about:config -> security.fileuri.strict_origin_policy -> false
 
 ### Included Libraries
 * AngularJS v1.6.9


### PR DESCRIPTION
## Summary
- fix Firefox-based typo in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68498b41e92883239ec0744d5fe1071d